### PR TITLE
将crypto替换为crypto-browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import json5 from 'json5'
-import crypto from 'crypto'
+import crypto from 'crypto-browserify'
 
 const SALT = process.env.VUE_APP_CONFIG_SALT || process.env.REACT_APP_CONFIG_SALT || 'tnP8DvkSp6MXtZHuP3ClhRTstakloIg'
 const ITER = process.env.VUE_APP_CONFIG_ITER || process.env.REACT_APP_CONFIG_ITER || 16

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "edwardpan2010@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "crypto": "^1.0.1",
+    "crypto-browserify": "^3.12.0",
     "json5": "^2.2.0"
   },
   "repository": {


### PR DESCRIPTION
将依赖的node运行时库crpyto替换为纯JavaScript实现的crypto-browserify，从而使得不依赖node运行时的开发工具如Vite、Snowpack得以正常运行该库。
benchmark如下：
使用crypto的版本：https://runkit.com/brizer/64d09b5e202b97000810b8c5
使用crypto-browserify的版本：https://runkit.com/brizer/64d0999a05578f000853ccfc